### PR TITLE
use `command -v foo` instead of `which foo`

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -118,11 +118,9 @@ if $mingw ; then
 fi
 
 if [ -z "$JAVA_HOME" ]; then
-  javaExecutable="`which javac`"
-  if [ -n "$javaExecutable" ] && ! [ "`expr \"$javaExecutable\" : '\([^ ]*\)'`" = "no" ]; then
+  if javaExecutable=$(command -v javac); then
     # readlink(1) is not available as standard on Solaris 10.
-    readLink=`which readlink`
-    if [ ! `expr "$readLink" : '\([^ ]*\)'` = "no" ]; then
+    if command -v readlink >/dev/null; then
       if $darwin ; then
         javaHome="`dirname \"$javaExecutable\"`"
         javaExecutable="`cd \"$javaHome\" && pwd -P`/javac"
@@ -146,7 +144,7 @@ if [ -z "$JAVACMD" ] ; then
       JAVACMD="$JAVA_HOME/bin/java"
     fi
   else
-    JAVACMD="`which java`"
+    JAVACMD=$(command -v java)
   fi
 fi
 


### PR DESCRIPTION
i got bitten by the mvnw using which when i tried to use it in a centos-based docker container, but it wouldn't work on my laptop with freebsd either.  commit message follows:

* which(1) is not standardized, leaning on the details of
  its output in case of failure limits mvnw's usability.
  eg. /usr/bin/which on FreeBSD outputs nothing on failure:
  ```
  % /usr/bin/which fubar; echo $?
  1
  % uname -sr
  FreeBSD 12.0-CURRENT
  ```
* which(1) is not universally available, esp. in containers.

* command -v is a builtin prescribed and precisely defined
  by POSIX:

  command -v

    Write a string to standard output that indicates the
    pathname or command that will be used by the shell, in the
    current shell execution environment (see Shell Execution
    Environment), to invoke command_name, but do not invoke
    command_name.

    * Utilities, regular built-in utilities, command_names
      including a <slash> character, and any
      implementation-defined functions that are found using
      the PATH variable (as described in Command Search and
      Execution), shall be written as absolute pathnames.

    * Shell functions, special built-in utilities, regular
      built-in utilities not associated with a PATH search,
      and shell reserved words shall be written as just their
      names.

    * An alias shall be written as a command line that
      represents its alias definition.

    * Otherwise, no output shall be written and the exit
      status shall reflect that the name was not found.