### PR TITLE
Enterprise Maven Repository interoperability

### DIFF
--- a/src/main/java/io/takari/maven/plugins/WrapperMojo.java
+++ b/src/main/java/io/takari/maven/plugins/WrapperMojo.java
@@ -11,6 +11,8 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.ArrayList;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -31,6 +33,8 @@ import io.tesla.proviso.archive.UnArchiver;
  */
 @Mojo(name = "wrapper", requiresProject = false, aggregator = true)
 public class WrapperMojo extends AbstractMojo {
+  private static final String DEFAULT_DOWNLOAD_BASE_URL="https://repo1.maven.org/maven2";
+  private static final String DEFAULT_MAVEN_VER = "3.6.0";
 
   @Parameter(defaultValue = "${session}", readonly = true)
   private MavenSession session;
@@ -38,8 +42,12 @@ public class WrapperMojo extends AbstractMojo {
   @Parameter(defaultValue = "0.4.3-SNAPSHOT", property = "version")
   private String version;
 
-  @Parameter(defaultValue = "3.6.0", property = "maven")
+  @Parameter(defaultValue = DEFAULT_MAVEN_VER, property = "maven")
   private String maven;
+
+  // Overriding Base URL for all external downloads of Maven Wrapper and Wrapper Plugin
+  @Parameter(property = "downloadBaseUrl")
+  private String downloadBaseUrl;
 
   @Parameter(property = "distributionUrl")
   private String distributionUrl;
@@ -53,15 +61,18 @@ public class WrapperMojo extends AbstractMojo {
     //
     File localRepository = new File(System.getProperty("user.home"), ".m2/repository");
     String artifactPath = String.format("io/takari/maven-wrapper/%s/maven-wrapper-%s.tar.gz", version, version);
-    String wrapperUrl = String.format("https://repo1.maven.org/maven2/%s", artifactPath);
+    String wrapperUrl = getDownloadBaseUrl() + "/" + artifactPath;
     File destination = new File(localRepository, artifactPath);
+
     Downloader downloader = new DefaultDownloader("mvnw", version);
     try {
+      getLog().info("Downloading wrapper from " + wrapperUrl);
       downloader.download(new URI(wrapperUrl), destination);
       UnArchiver unarchiver = UnArchiver.builder().useRoot(false).build();
       Path rootDirectory = Paths.get(session.getExecutionRootDirectory());
       unarchiver.unarchive(destination, rootDirectory.toFile());
-      overwriteDistributionUrl(rootDirectory, getDistributionUrl());
+      overwriteMavenWrapperProperties(rootDirectory);
+
       getLog().info("");
       getLog().info("The Maven Wrapper version " + version + " has been successfully setup for your project.");
       getLog().info("Using Apache Maven " + maven);
@@ -71,21 +82,44 @@ public class WrapperMojo extends AbstractMojo {
     }
   }
 
-  private void overwriteDistributionUrl(Path rootDirectory, String distributionUrl) throws IOException {
-    if (!isNullOrEmpty(distributionUrl)) {
+  private void overwriteMavenWrapperProperties(Path rootDirectory) throws IOException {
+    List<String> props = new ArrayList<>();
+
+    // Distrution URL could be altered by downloadBaseUrl, maven and distributionUrl
+    if (!isNullOrEmpty(downloadBaseUrl) || !isNullOrEmpty(distributionUrl) || !DEFAULT_MAVEN_VER.equals(maven)) {
+      props.add("distributionUrl=" + getDistributionUrl());
+    }
+    // Wrapper JAR URL could be overridden by downloadBaseUrl
+    if (!isNullOrEmpty(downloadBaseUrl)) {
+      String wrapperJarUrl = String.format("%s/io/takari/maven-wrapper/%s/maven-wrapper-%s.jar", 
+                                                getDownloadBaseUrl(),
+                                                version, 
+                                                version);
+      props.add("wrapperUrl=" + wrapperJarUrl);
+    }
+
+    if (!props.isEmpty()) {
       Path wrapperProperties = rootDirectory.resolve(Paths.get(".mvn", "wrapper", "maven-wrapper.properties"));
       if (Files.isWritable(wrapperProperties)) {
-        String distroKeyValue = "distributionUrl=" + distributionUrl;
-        Files.write(wrapperProperties, distroKeyValue.getBytes(Charset.forName("UTF-8")));
+        Files.write(wrapperProperties, props, Charset.forName("UTF-8"));
       }
     }
   }
 
-  protected String getDistributionUrl() {
-    if (isNullOrEmpty(distributionUrl) && !isNullOrEmpty(maven)) {
-      distributionUrl = String.format("https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/%s/apache-maven-%s-bin.zip", maven, maven);
+  private String getDownloadBaseUrl() {
+    // if overridden
+    if (!isNullOrEmpty(downloadBaseUrl)) {
+      return downloadBaseUrl;
     }
-    return distributionUrl;
+    return DEFAULT_DOWNLOAD_BASE_URL;
+  }
+
+  protected String getDistributionUrl() {
+    // if overridden
+    if (!isNullOrEmpty(distributionUrl)) {
+      return distributionUrl;
+    }
+    return String.format("%s/org/apache/maven/apache-maven/%s/apache-maven-%s-bin.zip", getDownloadBaseUrl(), maven, maven);
   }
 
   private static boolean isNullOrEmpty(String value) {


### PR DESCRIPTION
To make Maven-Wrapper work with enterprise internal maven repository:
- Allow to provide downloadBaseUrl property to wrapper plugin, which control the base URL to perform misc download for wrapper plugin and wrapper
- Populate wrapperUrl in maven-wrapper.properties if downloadBaseUrl is provided (hence the wrapper download URL is overridden).

### Possible change in behavior:
- distributionUrl is only populated in maven-wrapper.properties ONLY IF it is overridden (by providing distributionUrl or downloadBaseUrl property)

### Assumption:
- Assuming maven-wrapper is correct making use of wrapperUrl in maven-wrapper.properties (I have glanced at the code which seems it is, but I haven't tested it)

### Note:
Related to  https://github.com/takari/maven-wrapper/issues/95
Based on https://github.com/takari/takari-maven-plugin/pull/15 but with some extra cleanup and added population of wrapperUrl