### PR TITLE
Ensure wrapper properties points to jar instead of tar.gz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ changes. The following provides most information at an easier glance.
 In addition the [maven-wrapper changelog](https://github.com/takari/maven-wrapper/blob/master/CHANGELOG.md) contains
 useful information related to the wrapper goal of this plugin.
 
+## Version 0.7.4 - 2019-2-25
+
+- Use jar path for wrapper in properties file
+  - fixes https://github.com/takari/takari-maven-plugin/issues/19
+  - see https://github.com/takari/takari-maven-plugin/pull/20
+  - contributed by Manfred Moser http://www.simpligility.com
+  
+Release performed by Manfred Moser - http://www.simpligility.com
+
 ## Version 0.7.3 - 2019-02-25
 
 - Upgrade maven-wrapper:0.5.3 and hence the MVNW_REPOURL fix for mvnw

--- a/src/main/java/io/takari/maven/plugins/WrapperMojo.java
+++ b/src/main/java/io/takari/maven/plugins/WrapperMojo.java
@@ -100,7 +100,7 @@ public class WrapperMojo extends AbstractMojo {
    */
   private void updateMavenWrapperProperties(Path rootDirectory, String wrapperUrl, String distroUrl)
       throws IOException {
-	String wrapperJarUrl = wrapperUrl.replace("tar.gz", "jar");
+    String wrapperJarUrl = wrapperUrl.replace("tar.gz", "jar");
     List<String> props = new ArrayList<>();
     props.add("distributionUrl=" + distroUrl);
     props.add("wrapperUrl=" + wrapperJarUrl);

--- a/src/main/java/io/takari/maven/plugins/WrapperMojo.java
+++ b/src/main/java/io/takari/maven/plugins/WrapperMojo.java
@@ -100,9 +100,10 @@ public class WrapperMojo extends AbstractMojo {
    */
   private void updateMavenWrapperProperties(Path rootDirectory, String wrapperUrl, String distroUrl)
       throws IOException {
+	String wrapperJarUrl = wrapperUrl.replace("tar.gz", "jar");
     List<String> props = new ArrayList<>();
     props.add("distributionUrl=" + distroUrl);
-    props.add("wrapperUrl=" + wrapperUrl);
+    props.add("wrapperUrl=" + wrapperJarUrl);
 
     Path wrapperProperties = rootDirectory.resolve(Paths.get(".mvn", "wrapper", "maven-wrapper.properties"));
     if (Files.isWritable(wrapperProperties)) {


### PR DESCRIPTION
- fixes https://github.com/takari/takari-maven-plugin/issues/19

Signed-off-by: Manfred Moser <mmoser@apache.org>
Signed-off-by: Manfred Moser <manfred@simpligility.com>